### PR TITLE
perf(pencil): remove graphiteWidth option

### DIFF
--- a/.github/workflows/TestWorkdlows.yml
+++ b/.github/workflows/TestWorkdlows.yml
@@ -5,6 +5,7 @@ on:
 
 name: test workflow
 jobs:
+
   build:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
BREAKING CHANGE: The graphiteWidth option has been removed.
The default graphite width of 10mm is always used for performance reasons.